### PR TITLE
Fix combinations check

### DIFF
--- a/gshoppingflux/gshoppingflux.php
+++ b/gshoppingflux/gshoppingflux.php
@@ -2233,7 +2233,7 @@ class GShoppingFlux extends Module
             $product['material'] = '';
             $product['pattern'] = '';
             $product['size'] = '';
-            if (is_array($attributesResume) > 0 && $this->module_conf['export_attributes'] == 1) {
+            if ($attributesResume && $this->module_conf['export_attributes'] == 1) {
                 $original_product = $product;
                 $categories_value = $this->categories_values[$product['id_gcategory']];
                 $combinum = 0;


### PR DESCRIPTION
In thirty bees 1.4.0, method `Product::getAttributesResume` returns empty array for products without combinations. Previously, this method returned `false`.

Unfortunately that is braking change that affects this module. There is a check 

`is_array($attributesResume) > 0`

that now returns returns true even for products without combinations. This in turn results in products without combinations to be omitted from output file. 

The check is quite strange, I suspect the original code used to be

`count($attributesResume) > 0`

but was changed because it raised warnings in PHP7. I propose to change the check simply to to

`$attributesResume`

Related to thirtybees/thirtybees#1467