### PR TITLE
Fix: gender/color/material/pattern/size selects reset on save due to broken safeImplode() calls

### DIFF
--- a/gshoppingflux/gshoppingflux.php
+++ b/gshoppingflux/gshoppingflux.php
@@ -695,17 +695,17 @@ class GShoppingFlux extends Module
         $updated &= Configuration::updateValue('GS_SHIPPING_MODE', Tools::getValue('shipping_mode'), false, (int) $shop_group_id, (int) $shop_id);
         $updated &= Configuration::updateValue('GS_SHIPPING_PRICE', (float) Tools::getValue('shipping_price'), false, (int) $shop_group_id, (int) $shop_id);
         $updated &= Configuration::updateValue('GS_SHIPPING_COUNTRY', Tools::getValue('shipping_country'), false, (int) $shop_group_id, (int) $shop_id);
-        $updated &= Configuration::updateValue('GS_SHIPPING_COUNTRIES', ArrayHelper::safeImplode('shipping_countries'), false, (int) $shop_group_id, (int) $shop_id);
-        $updated &= Configuration::updateValue('GS_CARRIERS_EXCLUDED', ArrayHelper::safeImplode('carriers_excluded'), false, (int) $shop_group_id, (int) $shop_id);
+        $updated &= Configuration::updateValue('GS_SHIPPING_COUNTRIES', ArrayHelper::safeImplode((array) Tools::getValue('shipping_countries')), false, (int) $shop_group_id, (int) $shop_id);
+        $updated &= Configuration::updateValue('GS_CARRIERS_EXCLUDED', ArrayHelper::safeImplode((array) Tools::getValue('carriers_excluded')), false, (int) $shop_group_id, (int) $shop_id);
         $updated &= Configuration::updateValue('GS_IMG_TYPE', Tools::getValue('img_type'), false, (int) $shop_group_id, (int) $shop_id);
         $updated &= Configuration::updateValue('GS_MPN_TYPE', Tools::getValue('mpn_type'), false, (int) $shop_group_id, (int) $shop_id);
         $updated &= Configuration::updateValue('GS_GENDER', Tools::getValue('gender'), false, (int) $shop_group_id, (int) $shop_id);
         $updated &= Configuration::updateValue('GS_AGE_GROUP', Tools::getValue('age_group'), false, (int) $shop_group_id, (int) $shop_id);
         $updated &= Configuration::updateValue('GS_ATTRIBUTES', Tools::getValue('export_attributes'), false, (int) $shop_group_id, (int) $shop_id);
-        $updated &= Configuration::updateValue('GS_COLOR', ArrayHelper::safeImplode('color'), false, (int) $shop_group_id, (int) $shop_id);
-        $updated &= Configuration::updateValue('GS_MATERIAL', ArrayHelper::safeImplode('material'), false, (int) $shop_group_id, (int) $shop_id);
-        $updated &= Configuration::updateValue('GS_PATTERN', ArrayHelper::safeImplode('pattern'), false, (int) $shop_group_id, (int) $shop_id);
-        $updated &= Configuration::updateValue('GS_SIZE', ArrayHelper::safeImplode('size'), false, (int) $shop_group_id, (int) $shop_id);
+        $updated &= Configuration::updateValue('GS_COLOR', ArrayHelper::safeImplode((array) Tools::getValue('color')), false, (int) $shop_group_id, (int) $shop_id);
+        $updated &= Configuration::updateValue('GS_MATERIAL', ArrayHelper::safeImplode((array) Tools::getValue('material')), false, (int) $shop_group_id, (int) $shop_id);
+        $updated &= Configuration::updateValue('GS_PATTERN', ArrayHelper::safeImplode((array) Tools::getValue('pattern')), false, (int) $shop_group_id, (int) $shop_id);
+        $updated &= Configuration::updateValue('GS_SIZE', ArrayHelper::safeImplode((array) Tools::getValue('size')), false, (int) $shop_group_id, (int) $shop_id);
         $updated &= Configuration::updateValue('GS_EXPORT_MIN_PRICE', (float) Tools::getValue('export_min_price'), false, (int) $shop_group_id, (int) $shop_id);
         $updated &= Configuration::updateValue('GS_NO_GTIN', (bool) Tools::getValue('no_gtin'), false, (int) $shop_group_id, (int) $shop_id);
         $updated &= Configuration::updateValue('GS_SHIPPING_DIMENSION', (bool) Tools::getValue('shipping_dimension'), false, (int) $shop_group_id, (int) $shop_id);
@@ -797,7 +797,7 @@ class GShoppingFlux extends Module
     private function saveLanguage($shop_id, $shop_group_id)
     {
         $id_glang = (int) Tools::getValue('id_glang', 0);
-        $currencies = ArrayHelper::safeImplode('currencies');
+        $currencies = ArrayHelper::safeImplode((array) Tools::getValue('currencies'));
         $tax_included = (int) Tools::getValue('tax_included', 0);
         $export = (int) Tools::getValue('active', 0);
 


### PR DESCRIPTION
## Problem
When saving the main flux configuration (or the language/currency settings), several multi-select fields were silently wiped from the `configuration` table on every save, even if the user had selected values in the form.

## Root cause
`ArrayHelper::safeImplode()` expects an array, but several call sites in `saveFluxOptions()` and `saveLanguage()` were passing the **field name as a literal string** instead of first reading its actual submitted value with `Tools::getValue()`, e.g.:

```php
ArrayHelper::safeImplode('color')
```

instead of:

```php
ArrayHelper::safeImplode((array) Tools::getValue('color'))
```

Since `safeImplode()` only accepts arrays (`is_array()` check), passing a plain string always returned an empty string, so the corresponding configuration key was overwritten with `''` on every save — regardless of what was actually selected in the UI.

Interestingly, the correct pattern already existed elsewhere in the same file (`saveCategory()`), which made the inconsistency easy to confirm.

## Fields affected (all fixed)
- `GS_COLOR` (color feature select)
- `GS_MATERIAL` (material feature select)
- `GS_PATTERN` (pattern feature select)
- `GS_SIZE` (size feature select)
- `GS_SHIPPING_COUNTRIES`
- `GS_CARRIERS_EXCLUDED`
- Currencies in `saveLanguage()`

## Fix
Changed all affected calls to first read the actual POST value via `Tools::getValue($field)` before passing it (cast to array) to `ArrayHelper::safeImplode()`, matching the existing correct pattern used in `saveCategory()`.

## Testing
- `php -l gshoppingflux/gshoppingflux.php` — no syntax errors.
- Verified the diff only touches the broken `safeImplode()` call sites; no other behavior changed.
